### PR TITLE
refactor: use crypto.randomUUID for unique IDs

### DIFF
--- a/components/ChecklistApp.jsx
+++ b/components/ChecklistApp.jsx
@@ -100,7 +100,13 @@ const makeSections = () => DEFAULT_DATA.map(sec => ({
   items: sec.items.map(it => ({ ...it, status: 'todo', file: '', note: '', custom: false }))
 }));
 
-const uid = () => Math.random().toString(36).slice(2) + Date.now().toString(36);
+const uid = () => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  // Fallback for older browsers
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+};
 const deepClone = (obj) => { try { return structuredClone(obj); } catch { return JSON.parse(JSON.stringify(obj)); } };
 
 function makeCase(label = 'ผู้ยื่น 1', applicant = {}, profile = {}) {


### PR DESCRIPTION
## Summary
- use `crypto.randomUUID` for generating IDs with a fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e93fd7588832fa5a23b191149ec3d