### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,9 +3,15 @@
 @tailwind utilities;
 
 @layer components {
-  .btn { @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-indigo-600 text-white hover:bg-indigo-700; }
-  .btn-secondary { @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-white text-gray-900 border border-gray-300 hover:bg-gray-50; }
-  .btn-danger { @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-rose-500 text-white hover:bg-rose-600; }
+  .btn {
+    @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-indigo-600 text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-400;
+  }
+  .btn-secondary {
+    @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-white text-gray-900 border border-gray-300 hover:bg-gray-50 dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-600 dark:hover:bg-neutral-700;
+  }
+  .btn-danger {
+    @apply inline-flex items-center justify-center rounded-xl px-3.5 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 bg-rose-500 text-white hover:bg-rose-600 dark:bg-rose-600 dark:hover:bg-rose-500;
+  }
 }
 
 /* Print helpers */

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -7,8 +7,8 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="th">
-      <body className="min-h-screen bg-gradient-to-b from-neutral-50 to-neutral-100 text-neutral-900">
+    <html lang="th" className="dark" suppressHydrationWarning>
+      <body className="min-h-screen bg-gradient-to-b from-neutral-50 to-neutral-100 text-neutral-900 dark:from-neutral-900 dark:to-neutral-950 dark:text-neutral-100">
         {children}
       </body>
     </html>

--- a/components/ChecklistApp.jsx
+++ b/components/ChecklistApp.jsx
@@ -92,6 +92,7 @@ const DEFAULT_DATA = [
 const cls = (...t) => t.filter(Boolean).join(' ');
 const casesKey = 'doc-cases-v1';
 const activeKey = 'doc-activeCase-v1';
+const themeKey = 'doc-theme';
 const legacyKeys = { sections: 'doc-checklist-v2', profile: 'doc-profile-v1', applicant: 'doc-applicant-v1' };
 
 const makeSections = () => DEFAULT_DATA.map(sec => ({
@@ -203,6 +204,15 @@ function isItemApplicable(sectionId, itemId, profile) {
 export default function ChecklistApp() {
   const [cases, setCases] = useLocalStorageState(casesKey, INITIAL_CASES);
   const [activeId, setActiveId] = useLocalStorageState(activeKey, INITIAL_CASES[0]?.id || '');
+  const [theme, setTheme] = useLocalStorageState(themeKey, 'light');
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+    }
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
 
   const current = useMemo(() => cases.find(c => c.id === activeId) || cases[0], [cases, activeId]);
 
@@ -343,7 +353,7 @@ export default function ChecklistApp() {
   if (!current) return null;
   return (
     <div>
-      <Header />
+      <Header theme={theme} toggleTheme={toggleTheme} />
       <main className="mx-auto max-w-5xl px-4 pb-24">
         <CaseSwitcher
           cases={cases}
@@ -393,17 +403,20 @@ export default function ChecklistApp() {
   );
 }
 
-function Header() {
+function Header({ theme, toggleTheme }) {
   return (
-    <header className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b border-neutral-200">
+    <header className="sticky top-0 z-10 bg-white/80 backdrop-blur border-b border-neutral-200 dark:bg-neutral-900/80 dark:border-neutral-700">
       <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
         <h1 className="text-xl md:text-2xl font-semibold tracking-tight">รายการเอกสารเทียบคุณวุฒิ – Checklist</h1>
         <div className="flex items-center gap-2 text-xs md:text-sm">
-          <kbd className="rounded border px-1.5 py-0.5 bg-neutral-50 text-neutral-700">Ctrl/⌘K</kbd>
-          <span className="text-neutral-500">ค้นหา</span>
-          <span className="hidden md:inline text-neutral-300">|</span>
-          <kbd className="hidden md:inline rounded border px-1.5 py-0.5 bg-neutral-50 text-neutral-700">Ctrl/⌘S</kbd>
-          <span className="hidden md:inline text-neutral-500">บันทึก</span>
+          <kbd className="rounded border px-1.5 py-0.5 bg-neutral-50 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">Ctrl/⌘K</kbd>
+          <span className="text-neutral-500 dark:text-neutral-400">ค้นหา</span>
+          <span className="hidden md:inline text-neutral-300 dark:text-neutral-600">|</span>
+          <kbd className="hidden md:inline rounded border px-1.5 py-0.5 bg-neutral-50 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">Ctrl/⌘S</kbd>
+          <span className="hidden md:inline text-neutral-500 dark:text-neutral-400">บันทึก</span>
+          <button onClick={toggleTheme} className="ml-2 rounded border px-2 py-1 bg-neutral-50 text-neutral-700 hover:bg-neutral-100 dark:bg-neutral-700 dark:text-neutral-200 dark:border-neutral-600 dark:hover:bg-neutral-600">
+            {theme === 'dark' ? 'Light' : 'Dark'}
+          </button>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add `dark` class to html and apply dark theme colors
- style buttons for dark mode in global CSS
- add theme switcher with preference stored in localStorage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ef9909340832f91c10ee8d9eb1dcb