### PR TITLE
Improve modal accessibility and keyboard control

### DIFF
--- a/components/AddApplicantModal.jsx
+++ b/components/AddApplicantModal.jsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useRef, useId } from 'react';
+import useFocusTrap from './useFocusTrap';
 
 function TextField({ label, value, onChange, placeholder }) {
   return (
@@ -24,11 +25,22 @@ export default function AddApplicantModal({ onClose, onCreate }) {
   const [country, setCountry] = useState('');
   const [nationality, setNationality] = useState('Thai');
   const [phd, setPhd] = useState(false);
+  const dialogRef = useRef(null);
+  const titleId = useId();
+  const descId = useId();
+  useFocusTrap(dialogRef, onClose);
   return (
-    <div role="dialog" aria-modal="true" className="fixed inset-0 z-20 grid place-items-center bg-black/40 p-4" onClick={onClose}>
-      <div className="w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl" onClick={e => e.stopPropagation()}>
-        <h4 className="text-lg font-semibold">เพิ่มรายชื่อใหม่</h4>
-        <p className="mt-1 text-sm text-neutral-600">สร้างแบบฟอร์มใหม่สำหรับรายชื่อนี้</p>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      className="fixed inset-0 z-20 grid place-items-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div ref={dialogRef} className="w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl" onClick={e => e.stopPropagation()}>
+        <h4 id={titleId} className="text-lg font-semibold">เพิ่มรายชื่อใหม่</h4>
+        <p id={descId} className="mt-1 text-sm text-neutral-600">สร้างแบบฟอร์มใหม่สำหรับรายชื่อนี้</p>
         <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
           <TextField label="ชื่อ-นามสกุล" value={fullName} onChange={setFullName} placeholder="เช่น Pop Mee" />
           <TextField label="คุณวุฒิ" value={degree} onChange={setDegree} placeholder="เช่น M.Eng." />

--- a/components/ImportModal.jsx
+++ b/components/ImportModal.jsx
@@ -1,13 +1,25 @@
 'use client';
 
-import React from 'react';
+import React, { useRef, useId } from 'react';
+import useFocusTrap from './useFocusTrap';
 
 export default function ImportModal({ onClose, onPickFile }) {
+  const dialogRef = useRef(null);
+  const titleId = useId();
+  const descId = useId();
+  useFocusTrap(dialogRef, onClose);
   return (
-    <div role="dialog" aria-modal="true" className="fixed inset-0 z-20 grid place-items-center bg-black/40 p-4" onClick={onClose}>
-      <div className="w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl" onClick={e => e.stopPropagation()}>
-        <h4 className="text-lg font-semibold">นำเข้าสถานะจากไฟล์ JSON</h4>
-        <p className="mt-1 text-sm text-neutral-600">รองรับรูปแบบหลายรายชื่อ (v3) หรือไฟล์เดิมรายชื่อเดียว (v2)</p>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      className="fixed inset-0 z-20 grid place-items-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div ref={dialogRef} className="w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl" onClick={e => e.stopPropagation()}>
+        <h4 id={titleId} className="text-lg font-semibold">นำเข้าสถานะจากไฟล์ JSON</h4>
+        <p id={descId} className="mt-1 text-sm text-neutral-600">รองรับรูปแบบหลายรายชื่อ (v3) หรือไฟล์เดิมรายชื่อเดียว (v2)</p>
         <div className="mt-4 flex gap-2">
           <button onClick={onPickFile} className="btn">เลือกไฟล์</button>
           <button onClick={onClose} className="btn-secondary">ยกเลิก</button>

--- a/components/useFocusTrap.js
+++ b/components/useFocusTrap.js
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+
+export default function useFocusTrap(ref, onClose) {
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const focusableSelectors = [
+      'a[href]',
+      'area[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'button:not([disabled])',
+      'iframe',
+      'object',
+      'embed',
+      '[contenteditable]',
+      '[tabindex]:not([tabindex="-1"])',
+    ];
+
+    const focusables = node.querySelectorAll(focusableSelectors.join(','));
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const previouslyFocused = document.activeElement;
+    if (first) first.focus();
+
+    function handleKeyDown(e) {
+      if (e.key === 'Tab') {
+        if (focusables.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        if (onClose) onClose();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      if (previouslyFocused) previouslyFocused.focus();
+    };
+  }, [ref, onClose]);
+}


### PR DESCRIPTION
## Summary
- add generic `useFocusTrap` hook for trapping focus and handling Escape
- wire modals with focus trap and `aria-labelledby`/`aria-describedby`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f1cd6e620832f87a0d4b7543c1bdd